### PR TITLE
ci: update nixpkgs-following inputs alongside nixpkgs

### DIFF
--- a/.github/workflows/update-nixpkgs.yml
+++ b/.github/workflows/update-nixpkgs.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - name: Update nixpkgs input
-        run: nix flake update nixpkgs
+      - name: Update nixpkgs and the inputs that follow it
+        run: nix flake update nixpkgs treefmt-nix git-hooks
 
       - name: Check for changes
         id: diff
@@ -41,11 +41,13 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "Update nixpkgs input"
+          commit-message: "Update nixpkgs and tracking inputs"
           branch: update-nixpkgs
-          title: "Update nixpkgs input"
+          title: "Update nixpkgs and tracking inputs"
           body: |
-            Automated weekly update of the `nixpkgs` flake input.
+            Automated weekly update of the `nixpkgs` flake input, together
+            with the inputs that follow it (`treefmt-nix`, `git-hooks`), so
+            they advance in lockstep and stay compatible with `nixpkgs`.
 
       - name: Enable auto-merge
         if: steps.create-pr.outputs.pull-request-number


### PR DESCRIPTION
## What

The weekly `update-nixpkgs` workflow now runs `nix flake update nixpkgs treefmt-nix git-hooks` instead of `nix flake update nixpkgs`.

## Why

`treefmt-nix` and `git-hooks` both declare `inputs.nixpkgs.follows = "nixpkgs"`, so they are meant to track whatever `nixpkgs` the lock points at. Updating `nixpkgs` alone let them drift until a `nixpkgs` bump exposed an incompatibility.

That is exactly what happened in #17: the pinned `treefmt-nix` resolved prettier as `pkgs.nodePackages.prettier`, which threw once the `nixpkgs` bump crossed the removal of the `nodePackages` attribute set, breaking the `fmt`, `check`, and `eval-macos` jobs.

## Scope

- Advances `nixpkgs` together with the inputs that follow it, keeping the lock internally consistent.
- Leaves `llm-agents` to its own daily `update-llm-agents` workflow (so the two cadences stay separate and we avoid dueling `flake.lock` PRs).
- Leaves inputs that do not follow `nixpkgs` (`agent-box`, `systems`) untouched; they are low-churn and can be bumped manually if needed.
- PR title/body emitted by the workflow updated to reflect the broader scope.