### PR TITLE
chore: bump agent-box and add 0xferrous cachix substituter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1773806977,
-        "narHash": "sha256-GZkGH4BTZyMz0vF0dUSdyLN4qkhGRvLXBbd6Q+uQNVI=",
+        "lastModified": 1779007066,
+        "narHash": "sha256-ArBQsQejk1I4wF/+ayj0WU2c+LhkSg051d67X7OInlI=",
         "owner": "0xferrous",
         "repo": "agent-box",
-        "rev": "37e4f43abc74606a22dcd57b7140505c1fb0ba31",
+        "rev": "ba6e2b04e6577f6d8b717ec0ef640225627dc930",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,14 @@
   description = "Sandboxed OCI container images for AI coding agents";
 
   nixConfig = {
-    extra-substituters = [ "https://cache.numtide.com" ];
-    extra-trusted-public-keys = [ "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=" ];
+    extra-substituters = [
+      "https://cache.numtide.com"
+      "https://0xferrous.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+      "0xferrous.cachix.org-1:p38oLu+8I+EwBW6NCl+ffI8qn+WOtUeRzES/dYNuSUE="
+    ];
   };
 
   inputs = {


### PR DESCRIPTION
## What

- Bumps the `agent-box` input from `37e4f43` (2026-03-18) to `ba6e2b04` (2026-05-17).
- Adds `https://0xferrous.cachix.org` to `nixConfig.extra-substituters` (with its public key), mirroring upstream agent-box, so the `ab` build in the devShell is pulled from cache instead of rebuilt locally.

## Why

The pin was ~2 months and 12 commits behind upstream `main` (a clean fast-forward, `behind_by: 0`). `agent-box` does not follow `nixpkgs` and is not in the weekly auto-update set, so it had drifted.

## Upstream changes included (12 commits)

- `feat: named containers`
- `feat: propagate terminfo and capabilities` (upstream #26)
- `feat: allow configuring dns`
- `feat: default base_repo_dir to /`
- `feat: add repo_discovery_dirs`
- `feat: add timeout to repo discovery`
- `feat: write portal log files` (new portal logging)
- `feat/chore: configure cachix pushes`
- `fix: distinguish worktree vs main-repo root resolution`
- `fix: resolve_repo_id for jj workspaces`

## Impact

`agent-images` consumes only `agent-box.packages.${system}.default` (the `ab` CLI in the devShell). Upstream's `flake.nix` change was only a `nixConfig` addition, with no change to outputs or the package API, so this bump is non-breaking. Verified the devShell still evaluates and `nix fmt` is clean.