### PR TITLE
ci: add weekly agent-box auto-update workflow

### DIFF
--- a/.github/workflows/update-agent-box.yml
+++ b/.github/workflows/update-agent-box.yml
@@ -1,0 +1,48 @@
+name: Update agent-box
+
+on:
+  schedule:
+    - cron: "0 7 * * 3"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Update agent-box input
+        run: nix flake update agent-box
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet flake.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        id: create-pr
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "Update agent-box input"
+          branch: update-agent-box
+          title: "Update agent-box input"
+          body: |
+            Automated weekly update of the `agent-box` flake input.


### PR DESCRIPTION
## What

Adds a dedicated weekly workflow that runs `nix flake update agent-box` and opens a PR with the result, mirroring the existing `update-llm-agents` workflow.

## Why

`agent-box` does not follow `nixpkgs` and was not part of any auto-update set, so its input drifted ~2 months (12 commits) behind upstream before being noticed. A dedicated workflow keeps it current on its own cadence, consistent with how `llm-agents` is handled (independent, non-nixpkgs input gets its own workflow rather than being bundled into the nixpkgs job).

## Notes

- **No auto-merge** (unlike `update-llm-agents`): `agent-box` provides the `ab` CLI behavior consumed by the devShell, so its bumps should be reviewed before merging.
- Cadence is weekly (`0 7 * * 3`, Wednesday), staggered from the Monday `update-nixpkgs` job to avoid overlapping runs.
- Uses the same app-token + `peter-evans/create-pull-request` plumbing and the `update-agent-box` branch.

Validated locally with actionlint (the repo's `nix run .#actionlint`).