### PR TITLE
fix: restore llm-agents compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ reproducible and easy to customise.
 | `cursor-agent`   | [Cursor Agent](https://cursor.com/)                               | `nix build .#cursor-agent`   |
 | `droid`          | [Droid](https://factory.ai)                                       | `nix build .#droid`          |
 | `eca`            | [ECA](https://github.com/editor-code-assistant/eca)               | `nix build .#eca`            |
-| `forge`          | [Forge](https://github.com/antinomyhq/forge)                      | `nix build .#forge`          |
+| `forge`          | [Forgecode](https://github.com/tailcallhq/forgecode)              | `nix build .#forge`          |
 | `gemini-cli`     | [Gemini CLI](https://github.com/google-gemini/gemini-cli)         | `nix build .#gemini-cli`     |
 | `goose-cli`      | [Goose](https://github.com/block/goose)                           | `nix build .#goose-cli`      |
-| `iflow-cli`      | [iFlow CLI](https://github.com/iflow-ai/iflow-cli)                | `nix build .#iflow-cli`      |
 | `jules`          | [Jules](https://jules.google)                                     | `nix build .#jules`          |
 | `kilocode-cli`   | [Kilocode CLI](https://kilocode.ai/cli)                           | `nix build .#kilocode-cli`   |
 | `letta-code`     | [Letta Code](https://github.com/letta-ai/letta-code)              | `nix build .#letta-code`     |

--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1786003298,
-        "narHash": "sha256-AZH9k+x7DeEIcRND6v4paP6Y3BWbKa2Rsd1BUBd5PkY=",
+        "lastModified": 1787513672,
+        "narHash": "sha256-m6PmBf5wjWERb7Cirpt9nKWnKMrm3etbALECOo1mOes=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "423288c7213f051c816b9f960004c0adfa4aadfd",
+        "rev": "f39309b78f51e9fd45ea7b1e630e8add8a88f93b",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1785747939,
-        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
+        "lastModified": 1787209939,
+        "narHash": "sha256-WvvHR4kSQLAbtouMC/ruZ5UpLwlUcY3K4FAllMN+yGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
+        "rev": "391b592eb44808b3bd0cb80bb71b63a5a118b8bb",
         "type": "github"
       },
       "original": {
@@ -296,11 +296,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785945821,
-        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -69,10 +69,9 @@
             cursor-agent = { };
             droid = { };
             eca = { };
-            forge = { };
+            forge.agentPkg = "forgecode";
             gemini-cli = { };
             goose-cli = { };
-            iflow-cli = { };
             jules = { };
             kilocode-cli = { };
             letta-code = { };


### PR DESCRIPTION
## Summary

- Preserve the public `.#forge` image through the upstream `forgecode` package.
- Remove the discontinued `iflow-cli` image.
- Update the `llm-agents` lock data and README entries.

## Verification

- `nix flake show`.
- `nix flake check`.
- Built `.#forge`, `.#pi`, and `.#claude-code`.
- `just verify` passed formatting and lint checks.

The container-based Bats suites did not run because the review environment had neither Podman nor Docker.